### PR TITLE
DRY DSL and user extensibility

### DIFF
--- a/dired-filetype-face.el
+++ b/dired-filetype-face.el
@@ -2,11 +2,12 @@
 
 ;; Copyright (C) 2011~2012, 纪秀峰(Joseph) all rights reserved.
 ;; Created: 2011-04-04
-;; Last Update: 纪秀峰 2014-11-06 19:58:48
+;; Last Update: 纪秀峰 2015-02-04 13:25:17
 ;; Description: set faces for different file type in dired buffer.
 ;; Author: 纪秀峰(Joseph) <jixiuf@gmail.com>
-;; Version: 0.2.2
+;; Version: 0.2.3
 ;; URL: http://www.emacswiki.org/emacs/download/dired-filetype-face.el
+;; X-URL:https://github.com/jixiuf/dired-filetype-face
 ;; Keywords: dired filetype face custom
 ;; Compatibility: (Test on GNU Emacs 23.2.1 ,24.0.50)
 ;;
@@ -15,7 +16,7 @@
 ;;   `custom', `dired', `widget'.
 ;;
 ;; This file is NOT part of GNU Emacs
-;;
+
 ;;; License
 ;;
 ;; This program is free software; you can redistribute it and/or modify
@@ -55,58 +56,6 @@
 ;;
 ;; No need more.
 ;;
-
-;;; Commands:
-;;
-;; Below are complete command list:
-;;
-;;
-;;; Customizable Options:
-;;
-;; Below are customizable option list:
-;;
-;;  `dired-filetype-omit1-regexp'
-;;    regexp to match unimportanted file types
-;;    default = "^  .*\\.\\(elc\\|class\\|so\\|ko\\|la\\|o\\|al\\|ix\\|db\\|td\\|\\|dat\\|dll\\|Dll\\|DLL\\|sav\\|rdp\\|sys\\|SYS\\|prf\\|tlb\\|cat\\|bak\\)$"
-;;  `dired-filetype-omit2-regexp'
-;;    regexp to match backup or cache filetypes.
-;;    default = "^  .*\\(\\.git\\|\\.svn\\|~\\|#\\|%\\|\\.tmp\\|\\$DATA\\|:encryptable\\|\\.db_encryptable\\)$"
-;;  `dired-filetype-omit3-regexp'
-;;    regexp to match hidden files
-;;    default = " \\.\\(.*$\\)"
-;;  `dired-filetype-document-regexp'
-;;    regexp to match rich document filetypes
-;;    default = "^  .*\\.\\(pdf\\|chm\\|CHM\\|tex\\|doc\\|docx\\|xls\\|xlsx\\|ppt\\|pptx\\|odt\\|ott\\|rtf\\|sdw\\|ods\\|sxc\\|odp\\|otp\\|sdx\\|kdh\\|shx\\)$"
-;;  `dired-filetype-plain-regexp'
-;;    regexp to match plain text filetype
-;;    default = "^  .*\\.\\(TXT\\|txt\\|Txt\\|ini\\|INI\\|lrc\\|org\\|log\\|conf\\|CFG\\|cfg\\|properties\\|config\\|diff\\|patch\\|ebuild\\|inf\\|cnf\\|example\\|sample\\|default\\|m4\\)$"
-;;  `dired-filetype-common-regexp'
-;;    regexp to match common files
-;;    default = "^  .*\\(configure\\|INSTALL\\|README\\|readme\\|COPYING\\|CHANGES\\|LICENSE\\|ChangeLog\\|Makefile.in\\|MANIFEST.MF\\|NOTICE.txt\\|build.xml\\|Manifest\\|metadata.xml\\|install-sh\\|NEWS\\|HACKING\\|AUTHORS\\|todo\\|Todo\\|TODO\\|makefile\\|TAGS\\|tag\\)$"
-;;  `dired-filetype-xml-regexp'
-;;    regexp to match xml filetype
-;;    default = "^  .*\\.\\(html?\\|HTML?\\|xml\\|XML\\|xsl\\|xsd\\|rng\\|dtd\\|mht\\|jsp\\|asp\\|js\\|xaml\\)$"
-;;  `dired-filetype-compress-regexp'
-;;    regexp to match compressed filetypes
-;;    default = "^  .*\\.\\(tar\\|zip\\|ZIP\\|rar\\|RAR\\|tgz\\|gz\\|bzip2\\|bz2\\|7z\\|7Z\\|Z\\|z\\|xz\\|XZ\\|rpm\\|deb\\|lzma\\|cab\\|gzip\\|taz\\|wim\\|iso\\|tbz2\\|xar\\|XAR\\|jar\\|war\\|img\\)$"
-;;  `dired-filetype-source-regexp'
-;;    regexp to match source code filetypes
-;;    default = "^  .*\\.\\(c\\|cpp\\|java\\|JAVA\\|C\\|php\\|h\\|rb\\|pl\\|css\\|el\\|lua\\|sql\\|ahk\\|cs\\|erl\\|hrl\\)$"
-;;  `dired-filetype-execute-regexp'
-;;    regexp to match executable filetypes
-;;    default = "^  .*\\.\\(exe\\|EXE\\|bat\\|BAT\\|msi\\|MSI\\|\\|sh\\|run\\|reg\\|REG\\|com\\|COM\\|\\|vbx\\|VBX\\|bin\\|xpi\\|bundle\\)$"
-;;  `dired-filetype-music-regexp'
-;;    regexp to match music files
-;;    default = "^  .*\\.\\(mp3\\|MP3\\|wma\\|WMA\\|wav\\|WAV\\|mid\\|MID\\)$"
-;;  `dired-filetype-video-regexp'
-;;    regexp to match video filetypes
-;;    default = "^  .*\\.\\(flv\\|avi\\|AVI\\|mkv\\|rmvb\\|RMVB\\|mpeg\\|mpg\\|MPG\\|rm\\|RM\\|mp4\\|wmv\\|WMV\\|m4v\\|mov\\|ogg\\|ogv\\|3gp\\|f4v\\|swf\\)$"
-;;  `dired-filetype-image-regexp'
-;;    regexp to match images filetypes
-;;    default = "^  .*\\.\\(gif\\|GIF\\|jpg\\|JPG\\|bmp\\|BMP\\|jpeg?\\|JPEG?\\|png\\|PNG\\|xpm\\|svg\\)$"
-;;  `dired-filetype-lnk-regexp'
-;;    regexp to match lnk filetypes
-;;    default = "^  .*\\.\\(lnk\\|LNK\\|desktop\\|torrent\\|url\\|URL\\)$"
 
 ;;; Code:
 

--- a/dired-filetype-face.el
+++ b/dired-filetype-face.el
@@ -2,21 +2,20 @@
 
 ;; Copyright (C) 2011~2012, 纪秀峰(Joseph) all rights reserved.
 ;; Created: 2011-04-04
-;; Last Update: 纪秀峰 2015-02-04 13:25:17
+;; Last Update: 纪秀峰 2014-11-06 19:58:48
 ;; Description: set faces for different file type in dired buffer.
 ;; Author: 纪秀峰(Joseph) <jixiuf@gmail.com>
-;; Version: 0.2.3
+;; Version: 0.2.2
 ;; URL: http://www.emacswiki.org/emacs/download/dired-filetype-face.el
-;; X-URL:https://github.com/jixiuf/dired-filetype-face
 ;; Keywords: dired filetype face custom
 ;; Compatibility: (Test on GNU Emacs 23.2.1 ,24.0.50)
 ;;
 ;; Features that might be required by this library:
 ;;
-;; `dired' `custom'
+;;   `custom', `dired', `widget'.
 ;;
 ;; This file is NOT part of GNU Emacs
-
+;;
 ;;; License
 ;;
 ;; This program is free software; you can redistribute it and/or modify
@@ -57,6 +56,58 @@
 ;; No need more.
 ;;
 
+;;; Commands:
+;;
+;; Below are complete command list:
+;;
+;;
+;;; Customizable Options:
+;;
+;; Below are customizable option list:
+;;
+;;  `dired-filetype-omit1-regexp'
+;;    regexp to match unimportanted file types
+;;    default = "^  .*\\.\\(elc\\|class\\|so\\|ko\\|la\\|o\\|al\\|ix\\|db\\|td\\|\\|dat\\|dll\\|Dll\\|DLL\\|sav\\|rdp\\|sys\\|SYS\\|prf\\|tlb\\|cat\\|bak\\)$"
+;;  `dired-filetype-omit2-regexp'
+;;    regexp to match backup or cache filetypes.
+;;    default = "^  .*\\(\\.git\\|\\.svn\\|~\\|#\\|%\\|\\.tmp\\|\\$DATA\\|:encryptable\\|\\.db_encryptable\\)$"
+;;  `dired-filetype-omit3-regexp'
+;;    regexp to match hidden files
+;;    default = " \\.\\(.*$\\)"
+;;  `dired-filetype-document-regexp'
+;;    regexp to match rich document filetypes
+;;    default = "^  .*\\.\\(pdf\\|chm\\|CHM\\|tex\\|doc\\|docx\\|xls\\|xlsx\\|ppt\\|pptx\\|odt\\|ott\\|rtf\\|sdw\\|ods\\|sxc\\|odp\\|otp\\|sdx\\|kdh\\|shx\\)$"
+;;  `dired-filetype-plain-regexp'
+;;    regexp to match plain text filetype
+;;    default = "^  .*\\.\\(TXT\\|txt\\|Txt\\|ini\\|INI\\|lrc\\|org\\|log\\|conf\\|CFG\\|cfg\\|properties\\|config\\|diff\\|patch\\|ebuild\\|inf\\|cnf\\|example\\|sample\\|default\\|m4\\)$"
+;;  `dired-filetype-common-regexp'
+;;    regexp to match common files
+;;    default = "^  .*\\(configure\\|INSTALL\\|README\\|readme\\|COPYING\\|CHANGES\\|LICENSE\\|ChangeLog\\|Makefile.in\\|MANIFEST.MF\\|NOTICE.txt\\|build.xml\\|Manifest\\|metadata.xml\\|install-sh\\|NEWS\\|HACKING\\|AUTHORS\\|todo\\|Todo\\|TODO\\|makefile\\|TAGS\\|tag\\)$"
+;;  `dired-filetype-xml-regexp'
+;;    regexp to match xml filetype
+;;    default = "^  .*\\.\\(html?\\|HTML?\\|xml\\|XML\\|xsl\\|xsd\\|rng\\|dtd\\|mht\\|jsp\\|asp\\|js\\|xaml\\)$"
+;;  `dired-filetype-compress-regexp'
+;;    regexp to match compressed filetypes
+;;    default = "^  .*\\.\\(tar\\|zip\\|ZIP\\|rar\\|RAR\\|tgz\\|gz\\|bzip2\\|bz2\\|7z\\|7Z\\|Z\\|z\\|xz\\|XZ\\|rpm\\|deb\\|lzma\\|cab\\|gzip\\|taz\\|wim\\|iso\\|tbz2\\|xar\\|XAR\\|jar\\|war\\|img\\)$"
+;;  `dired-filetype-source-regexp'
+;;    regexp to match source code filetypes
+;;    default = "^  .*\\.\\(c\\|cpp\\|java\\|JAVA\\|C\\|php\\|h\\|rb\\|pl\\|css\\|el\\|lua\\|sql\\|ahk\\|cs\\|erl\\|hrl\\)$"
+;;  `dired-filetype-execute-regexp'
+;;    regexp to match executable filetypes
+;;    default = "^  .*\\.\\(exe\\|EXE\\|bat\\|BAT\\|msi\\|MSI\\|\\|sh\\|run\\|reg\\|REG\\|com\\|COM\\|\\|vbx\\|VBX\\|bin\\|xpi\\|bundle\\)$"
+;;  `dired-filetype-music-regexp'
+;;    regexp to match music files
+;;    default = "^  .*\\.\\(mp3\\|MP3\\|wma\\|WMA\\|wav\\|WAV\\|mid\\|MID\\)$"
+;;  `dired-filetype-video-regexp'
+;;    regexp to match video filetypes
+;;    default = "^  .*\\.\\(flv\\|avi\\|AVI\\|mkv\\|rmvb\\|RMVB\\|mpeg\\|mpg\\|MPG\\|rm\\|RM\\|mp4\\|wmv\\|WMV\\|m4v\\|mov\\|ogg\\|ogv\\|3gp\\|f4v\\|swf\\)$"
+;;  `dired-filetype-image-regexp'
+;;    regexp to match images filetypes
+;;    default = "^  .*\\.\\(gif\\|GIF\\|jpg\\|JPG\\|bmp\\|BMP\\|jpeg?\\|JPEG?\\|png\\|PNG\\|xpm\\|svg\\)$"
+;;  `dired-filetype-lnk-regexp'
+;;    regexp to match lnk filetypes
+;;    default = "^  .*\\.\\(lnk\\|LNK\\|desktop\\|torrent\\|url\\|URL\\)$"
+
 ;;; Code:
 
 (require 'dired)
@@ -67,281 +118,185 @@
   :prefix "dired-filetype-face-"
   :group 'dired-faces)
 
-(defface dired-filetype-omit
-  '((t (:foreground "Chartreuse")))
-  "face for omit files"
-  :group 'dired-filetype-face )
+(defmacro deffiletype-face (type color &optional type-for-symbol)
+  "Declare a dired filetype face for displaying TYPE files in the given COLOR.
 
-(defcustom dired-filetype-omit1-regexp
+If TYPE-FOR-SYMBOL is nil, define a face named
+  dired-filetype-TYPE
+
+Otherwise, define a face named
+  dired-filetype-TYPE-FOR-SYMBOL
+
+COLOR may be a string or a list of face properties. If a string,
+it is either a color name such as \"Chartreuse\" or a color
+hexadecimal RGB number such as \"#xaaaaaa\"."
+  `(defface ,(intern (concat "dired-filetype-" (downcase (or type-for-symbol type))))
+     ,(if (stringp color)
+       `(quote ((t (:foreground ,color))))
+       color)
+     ,(format "Face for displaying %s files in dired." type)
+     :group 'dired-filetype-face))
+
+(defmacro deffiletype-face-regexp (regexp type-for-symbol &optional type-for-docstring)
+  "Declare a filetype REGEXP option for dired to colorize matching files.
+
+Use TYPE-FOR-SYMBOL to derive the option symbol.
+
+If TYPE-FOR-DOCSTRING is not nil, use that in the option
+docstring instead of TYPE-FOR-SYMBOL."
+  `(defcustom ,(intern (format "dired-filetype-%s-regexp" type-for-symbol))
+     ,regexp
+     ,(format "Regexp to match %s file-types in dired." (or type-for-docstring type-for-symbol))
+     :type 'string
+     :group 'dired-filetype-face))
+
+(defconst dired-filetype-face-font-lock-keywords
+  '(("(\\(deffiletype-face\\(?:-\\(?:regexp\\|set-fun\\)\\)?\\)\\_>"
+     (1 font-lock-keyword-face))))
+
+(font-lock-add-keywords 'emacs-lisp-mode dired-filetype-face-font-lock-keywords)
+
+(deffiletype-face "omit" "Chartreuse")
+
+(deffiletype-face-regexp
   "^  .*\\.\\(elc\\|class\\|so\\|ko\\|la\\|o\\|al\\|ix\\|db\\|td\\|\\|dat\\|dll\\|Dll\\|DLL\\|sav\\|rdp\\|sys\\|SYS\\|prf\\|tlb\\|cat\\|bak\\)$"
-  "regexp to match unimportanted file types"
-  :type 'string
-  :group 'dired-filetype-face)
+  "omit1"
+  "unimportant")
 
-(defcustom dired-filetype-omit2-regexp
+(deffiletype-face-regexp
   "^  .*\\(\\.git\\|\\.svn\\|~\\|#\\|%\\|\\.tmp\\|\\$DATA\\|:encryptable\\|\\.db_encryptable\\)$"
-  "regexp to match backup or cache filetypes."
-  :type 'string
-  :group 'dired-filetype-face)
+  "omit2"
+  "backup or cache")
 
-(defcustom dired-filetype-omit3-regexp
-  " \\.\\(.*$\\)"
-  "regexp to match hidden files"
-  :type 'string
-  :group 'dired-filetype-face)
+(deffiletype-face-regexp " \\.\\(.*$\\)" "omit3" "hidden")
 
-(defface dired-filetype-document
-  '((t (:foreground "DarkCyan")))
-  "face for rich document files "
-  :group 'dired-filetype-face )
+(deffiletype-face "rich document" "DarkCyan" "document")
 
-(defcustom dired-filetype-document-regexp
+(deffiletype-face-regexp
   "^  .*\\.\\(pdf\\|chm\\|CHM\\|tex\\|doc\\|docx\\|xls\\|xlsx\\|ppt\\|pptx\\|odt\\|ott\\|rtf\\|sdw\\|ods\\|sxc\\|odp\\|otp\\|sdx\\|kdh\\|shx\\)$"
-  "regexp to match rich document filetypes"
-  :type 'string
-  :group 'dired-filetype-face)
+  "document"
+  "rich document")
 
-(defface   dired-filetype-plain
-  '((t (:foreground "MediumPurple")))
-  "face for plain text files "
-  :group 'dired-filetype-face)
+(deffiletype-face "plain text" "MediumPurple" "plain")
 
-(defcustom dired-filetype-plain-regexp
+(deffiletype-face-regexp
   "^  .*\\.\\(TXT\\|txt\\|Txt\\|ini\\|INI\\|lrc\\|org\\|log\\|conf\\|CFG\\|cfg\\|properties\\|config\\|diff\\|patch\\|ebuild\\|inf\\|cnf\\|example\\|sample\\|default\\|m4\\)$"
-  "regexp to match plain text filetype"
-  :type 'string
-  :group 'dired-filetype-face)
+  "plain"
+  "plain text")
 
-(defface dired-filetype-common
-  '((t (:foreground "Peru")))
-  "face for common file names"
-  :group 'dired-filetype-face)
+(deffiletype-face "common" "Peru")
 
-(defcustom dired-filetype-common-regexp
+(deffiletype-face-regexp
   "^  .*\\(configure\\|INSTALL\\|README\\|readme\\|COPYING\\|CHANGES\\|LICENSE\\|ChangeLog\\|Makefile.in\\|MANIFEST.MF\\|NOTICE.txt\\|build.xml\\|Manifest\\|metadata.xml\\|install-sh\\|NEWS\\|HACKING\\|AUTHORS\\|todo\\|Todo\\|TODO\\|makefile\\|TAGS\\|tag\\)$"
-  "regexp to match common files"
-  :type 'string
-  :group 'dired-filetype-face)
+  "common")
 
-(defface dired-filetype-xml
-  '((t (:foreground "Chocolate")))
-  "face for xml type files"
-  :group 'dired-filetype-face)
+(deffiletype-face "XML" "Chocolate")
 
-(defcustom dired-filetype-xml-regexp
+(deffiletype-face-regexp
   "^  .*\\.\\(html?\\|HTML?\\|xml\\|XML\\|xsl\\|xsd\\|rng\\|dtd\\|mht\\|jsp\\|asp\\|js\\|xaml\\)$"
-  "regexp to match xml filetype"
-  :type 'string
-  :group 'dired-filetype-face)
-;;SlateBlue
+  "xml"
+  "XML")
 
-(defface dired-filetype-compress
-  '((t (:foreground "Orchid")))
-  "face for compressed files "
-  :group 'dired-filetype-face)
+(deffiletype-face "compressed" "Orchid" "compress")
 
-(defcustom dired-filetype-compress-regexp
+(deffiletype-face-regexp
   "^  .*\\.\\(tar\\|zip\\|ZIP\\|rar\\|RAR\\|tgz\\|gz\\|bzip2\\|bz2\\|7z\\|7Z\\|Z\\|z\\|xz\\|XZ\\|rpm\\|deb\\|lzma\\|cab\\|gzip\\|taz\\|wim\\|iso\\|tbz2\\|xar\\|XAR\\|jar\\|war\\|img\\)$"
-  "regexp to match compressed filetypes"
-  :type 'string
-  :group 'dired-filetype-face)
+  "compress"
+  "compressed")
 
-(defface dired-filetype-source
-  '((t (:foreground "SpringGreen")))
-  "face for source code files "
-  :group 'dired-filetype-face)
+(deffiletype-face "source code" "SpringGreen" "source")
 
-(defcustom dired-filetype-source-regexp
+(deffiletype-face-regexp
   "^  .*\\.\\(c\\|cpp\\|java\\|JAVA\\|C\\|php\\|h\\|rb\\|pl\\|css\\|el\\|lua\\|sql\\|ahk\\|cs\\|erl\\|hrl\\|go\\)$"
-  "regexp to match source code filetypes"
-  :type 'string
-  :group 'dired-filetype-face)
+  "source"
+  "source code")
 
+(deffiletype-face "executable" "green" "execute")
 
-(defface dired-filetype-execute
-  '((((class color)) :foreground "green"))
-  "face for executable files "
-  :group 'dired-filetype-face)
-
-(defcustom dired-filetype-execute-regexp
+(deffiletype-face-regexp
   "^  .*\\.\\(exe\\|EXE\\|bat\\|BAT\\|msi\\|MSI\\|\\|sh\\|run\\|reg\\|REG\\|com\\|COM\\|\\|vbx\\|VBX\\|bin\\|xpi\\|bundle\\)$"
-  "regexp to match executable filetypes"
-  :type 'string
-  :group 'dired-filetype-face)
+  "execute"
+  "executable")
 
-(defface dired-filetype-music
-  '((t (:foreground "SteelBlue")))
-  "face for music files "
-  :group 'dired-filetype-face)
+(deffiletype-face "music" "SteelBlue")
 
-(defcustom dired-filetype-music-regexp
+(deffiletype-face-regexp
   "^  .*\\.\\(mp3\\|MP3\\|wma\\|WMA\\|wav\\|WAV\\|mid\\|MID\\|ogg\\|OGG\\|aac\\|AAC\\|flac\\|FLAC\\|m4a\\|M4A\\)$"
-  "regexp to match music files"
-  :type 'string
-  :group 'dired-filetype-face)
+  "music")
 
-(defface dired-filetype-video
-  '((t (:foreground "SandyBrown")))
-  "face for video files "
-  :group 'dired-filetype-face)
+(deffiletype-face "video" "SandyBrown")
 
-(defcustom dired-filetype-video-regexp
+(deffiletype-face-regexp
   "^  .*\\.\\(flv\\|FLV\\|avi\\|AVI\\|mkv\\|rmvb\\|RMVB\\|mpeg\\|mpg\\|MPG\\|rm\\|RM\\|mp4\\|wmv\\|WMV\\|m4v\\|mov\\|ogm\\|ogv\\|3gp\\|f4v\\|swf\\|webm\\|divx\\|xvid\\|rm\\)$"
-  "regexp to match video filetypes"
-  :type 'string
-  :group 'dired-filetype-face)
+  "video")
 
-(defface dired-filetype-image
-  '((t (:foreground "MediumPurple")))
-  "face for pictures."
-  :group 'dired-filetype-face)
+(deffiletype-face "image" "MediumPurple")
 
-(defcustom dired-filetype-image-regexp
+(deffiletype-face-regexp
   "^  .*\\.\\(gif\\|GIF\\|jpg\\|JPG\\|bmp\\|BMP\\|jpeg?\\|JPEG?\\|png\\|PNG\\|xpm\\|svg\\|icns\\|odg\\|tiff?\\|epsf?\\|icon?\\|pict?\\|tga\\|pcx\\|xbm\\)$"
-  "regexp to match images filetypes"
-  :type 'string
-  :group 'dired-filetype-face)
+  "image")
 
-(defface dired-filetype-lnk
+(deffiletype-face
+  "link"
   '((((class color) (background dark)) :foreground "yellow" :background "forest green") (t ()))
-  "face for lnk files "
-  :group 'dired-filetype-face)
+  "lnk")
 
-(defcustom dired-filetype-lnk-regexp
+(deffiletype-face-regexp
   "^  .*\\.\\(lnk\\|LNK\\|desktop\\|torrent\\|url\\|URL\\)$"
-  "regexp to match lnk filetypes"
-  :type 'string
-  :group 'dired-filetype-face)
+  "lnk" "link")
 
 ;;; Custom ends here.
 
-(defun dired-filetype-set-document-face ()
-  "dired-filetype-face for rich documents:"
-  (font-lock-add-keywords
-   nil `((,dired-filetype-document-regexp
-          (".+"
-           (dired-move-to-filename)
-           nil
-           (0 'dired-filetype-document)))))
-  )
+(defmacro deffiletype-face-set-fun (type &optional type-for-docstring type-for-symbol type-for-face)
+  "Declare a function to tell dired how to display TYPE files.
+If not nil, use TYPE-FOR-DOCSTRING instead of TYPE for documentation.
+If not nil, use TYPE-FOR-SYMBOL instead of TYPE to derive the function symbol.
+If not nil, use TYPE-FOR-FACE instead of TYPE to derive the symbol for the associated face."
+  `(defun ,(intern (format "dired-filetype-set-%s-face" (or type-for-symbol type))) ()
+     ,(format "Set dired-filetype-face for %s files." (or type-for-docstring type))
+     (font-lock-add-keywords
+       nil
+       (list
+         (cons
+           ,(intern
+              (format "dired-filetype-%s-regexp" (downcase type)))
+           '((".+"
+              (dired-move-to-filename)
+              nil
+              (0
+                (quote
+                  ,(intern
+                     (concat
+                     "dired-filetype-"
+                     (or type-for-face type))))))))))))
 
-(defun dired-filetype-set-plain-face ()
-  "dired-filetype-face for plain text:"
-  (font-lock-add-keywords
-   nil `((,dired-filetype-plain-regexp
-          (".+"
-           (dired-move-to-filename)
-           nil
-           (0 'dired-filetype-plain )))))
-  )
+(deffiletype-face-set-fun "document" "rich document")
 
-(defun dired-filetype-set-common-face ()
-  "dired-filetype-face for common files :"
-  (font-lock-add-keywords
-   nil `((,dired-filetype-common-regexp
-          (".+"
-           (dired-move-to-filename)
-           nil
-           (0 'dired-filetype-common))))))
+(deffiletype-face-set-fun "plain" "plain text")
 
-(defun dired-filetype-set-xml-face ()
-  "dired-filetype-face for xml:"
-  (font-lock-add-keywords
-   nil `((,dired-filetype-xml-regexp
-          (".+"
-           (dired-move-to-filename)
-           nil
-           (0 'dired-filetype-xml))))))
+(deffiletype-face-set-fun "common")
 
-(defun dired-filetype-set-compress-face ()
-  "dired-filetype-face for compressed files:"
-  (font-lock-add-keywords
-   nil `((,dired-filetype-compress-regexp
-          (".+"
-           (dired-move-to-filename)
-           nil
-           (0 'dired-filetype-compress))))))
+(deffiletype-face-set-fun "XML")
 
-(defun dired-filetype-set-source-face ()
-  "dired-filetype-face for source code files :"
-  (font-lock-add-keywords
-   nil `((,dired-filetype-source-regexp
-          (".+"
-           (dired-move-to-filename)
-           nil
-           (0 'dired-filetype-source))))))
+(deffiletype-face-set-fun "compress" "compressed")
 
-(defun dired-filetype-set-omit-face ()
-  "dired-filetype-face for files can be omitted:"
-  (font-lock-add-keywords
-   nil `((,dired-filetype-omit1-regexp
-          (".+"
-           (dired-move-to-filename)
-           nil
-           (0 'dired-filetype-omit))))))
+(deffiletype-face-set-fun "source" "source code")
 
-(defun dired-filetype-set-omit2-face ()
-  "dired-filetype-face for backup and cache files:"
-  (font-lock-add-keywords
-   nil `(( ,dired-filetype-omit2-regexp
-           (".+"
-            (dired-move-to-filename)
-            nil
-            (0 'dired-filetype-omit))))))
+(deffiletype-face-set-fun "omit1" "unimportant" "omit" "omit")
 
-(defun dired-filetype-set-omit3-face ()
-  "dired-filetype-face for hidden files:"
-  (font-lock-add-keywords
-   nil `(( ,dired-filetype-omit3-regexp
-           (".+"
-            (dired-move-to-filename)
-            nil
-            (0 'dired-filetype-omit))))))
+(deffiletype-face-set-fun "omit2" "backup and cache" nil "omit")
 
-(defun dired-filetype-set-exe-face ()
-  "dired-filetype-face for executable files:"
-  (font-lock-add-keywords
-   nil `((,dired-filetype-execute-regexp
-          (".+"
-           (dired-move-to-filename)
-           nil
-           (0 'dired-filetype-execute))))))
+(deffiletype-face-set-fun "omit3" "hidden" nil "omit")
 
-(defun dired-filetype-set-music-face ()
-  "dired-filetype-faces for audio files:"
-  (font-lock-add-keywords
-   nil `((,dired-filetype-music-regexp
-          (".+"
-           (dired-move-to-filename)
-           nil
-           (0 'dired-filetype-music ))))))
+(deffiletype-face-set-fun "execute" "executable" "exe")
 
-(defun dired-filetype-set-video-face ()
-  "dired-filetype-face for video files"
-  (font-lock-add-keywords
-   nil `((,dired-filetype-video-regexp
-          (".+"
-           (dired-move-to-filename)
-           nil
-           (0 'dired-filetype-video))))))
+(deffiletype-face-set-fun "music" "audio")
 
-(defun dired-filetype-set-image-face ()
-  "dired-filetype-face for images."
-  (font-lock-add-keywords
-   nil `((,dired-filetype-image-regexp
-          (".+"
-           (dired-move-to-filename)
-           nil
-           (0 'dired-filetype-image))))))
+(deffiletype-face-set-fun "video")
 
-(defun dired-filetype-set-lnk-face ()
-  "dired-filetype-face for lnk files"
-  (font-lock-add-keywords
-   nil `((,dired-filetype-lnk-regexp
-           (".+"
-            (dired-move-to-filename)
-            nil
-            (0 'dired-filetype-lnk))))))
+(deffiletype-face-set-fun "image")
+
+(deffiletype-face-set-fun "lnk" "link")
 
 ;;;###autoload
 (defun dired-filetype-face-mode-func()


### PR DESCRIPTION
The macros introduced here reduce redundant boilerplate code, leaving all existing face, user option and function declarations intact, and also provide users with a facility for consistenlty extending the set of recognized filetype groupings with their own user-defined sets. It is a big change to the look of the file, but I hope you will accept it, since it delivers exactly the same functionality using much less code and, as I say, adds the user-extensibility feature.
